### PR TITLE
Adding support for SQLite and MySQL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,3 @@ gemspec
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
-
-gem "sqlite3", "~> 1.3.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quantum_fields (0.1.0)
+    quantum_fields (0.1.1)
       rails (> 5)
 
 GEM
@@ -73,7 +73,6 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    pg (1.1.4)
     rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -135,7 +134,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  pg
   quantum_fields!
   rspec
   sqlite3 (~> 1.3.6)

--- a/lib/quantum_fields.rb
+++ b/lib/quantum_fields.rb
@@ -6,6 +6,7 @@ require 'active_support/concern'
 require 'quantum_fields/active_record_patch'
 require 'quantum_fields/no_sqlize'
 require 'quantum_fields/railtie'
+require 'quantum_fields/support'
 require 'quantum_fields/validation_injector'
 
 # A module to abstract a noSQL aproach into SQL records, using a `parameters`

--- a/lib/quantum_fields/active_record_patch.rb
+++ b/lib/quantum_fields/active_record_patch.rb
@@ -6,9 +6,8 @@ ActiveRecord::PredicateBuilder.class_eval do
       bind = build_bind_attribute(attribute.name, value)
       attribute.eq(bind)
     elsif table.send('klass').respond_to?(:fields_column) && !table.send('klass').column_names.include?(attribute.name)
-      json_key = attribute.name
+      op = QuantumFields::Support.field_node(table.send('klass').arel_table[table.send('klass').fields_column], attribute.name)
       attribute.name = table.send('klass').fields_column.to_s
-      op = Arel::Nodes::InfixOperation.new('->>', table.send('klass').arel_table[table.send('klass').fields_column], Arel::Nodes.build_quoted(json_key))
       bind = build_bind_attribute(op, value)
       op.eq(bind)
     else
@@ -21,9 +20,8 @@ ActiveRecord::Relation.class_eval do
     if klass.column_names.include?(name.to_s) || !klass.respond_to?(:fields_column)
       klass.arel_attribute(name, table)
     else
-      Arel::Nodes::InfixOperation.new('->>',
-                                      klass.arel_table[klass.fields_column],
-                                      Arel::Nodes.build_quoted(name))
+      QuantumFields::Support.field_node klass.arel_table[klass.fields_column],
+                                        name
     end
   end
 end

--- a/lib/quantum_fields/support.rb
+++ b/lib/quantum_fields/support.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'quantum_fields/support/postgresql'
+require 'quantum_fields/support/mysql'
+require 'quantum_fields/support/sqlite3'
+
+module QuantumFields
+  # Module to add support to different database operation
+  module Support
+    class << self
+      # Redirects call to current database context support module
+      def field_node(field, key)
+        ('QuantumFields::Support::' +
+          ActiveRecord::Base.connection
+                            .instance_values['config'][:adapter]
+                            .classify).constantize.field_node(field, key)
+      end
+    end
+  end
+end

--- a/lib/quantum_fields/support/mysql.rb
+++ b/lib/quantum_fields/support/mysql.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module QuantumFields
+  module Support
+    # Abstracts MySQL support for quantum_fields operations
+    module Mysql
+      class << self
+        # Returns an Arel node in the context of given field and JSON key,
+        # which in this context constructs as "json_extract("my_models"."my_json_field", '$.key')"
+        def field_node(field, key)
+          Arel::Nodes::NamedFunction.new('json_extract',
+                                         [field,
+                                          Arel::Nodes.build_quoted("$.#{key}")])
+        end
+      end
+    end
+  end
+end

--- a/lib/quantum_fields/support/postgresql.rb
+++ b/lib/quantum_fields/support/postgresql.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module QuantumFields
+  module Support
+    # Abstracts PostgreSQL support for quantum_fields operations
+    module Postgresql
+      class << self
+        # Returns an Arel node in the context of given field and JSON key,
+        # which in this context constructs as "'my_json_field'->>'my_key'"
+        def field_node(field, key)
+          Arel::Nodes::InfixOperation.new('->>',
+                                          field,
+                                          Arel::Nodes.build_quoted(key))
+        end
+      end
+    end
+  end
+end

--- a/lib/quantum_fields/support/sqlite3.rb
+++ b/lib/quantum_fields/support/sqlite3.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module QuantumFields
+  module Support
+    # Abstracts SQLite support for quantum_fields operations
+    module Sqlite3
+      class << self
+        # Returns an Arel node in the context of given field and JSON key,
+        # which in this context constructs as "json_extract("my_models"."my_json_field", '$.key')"
+        def field_node(field, key)
+          Arel::Nodes::NamedFunction.new('json_extract',
+                                         [field,
+                                          Arel::Nodes.build_quoted("$.#{key}")])
+        end
+      end
+    end
+  end
+end

--- a/lib/quantum_fields/version.rb
+++ b/lib/quantum_fields/version.rb
@@ -1,3 +1,3 @@
 module QuantumFields
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/quantum_fields.gemspec
+++ b/quantum_fields.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", "> 5"
 
-  spec.add_development_dependency "pg"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "sqlite3", "~> 1.3.6"
 end

--- a/spec/quantum_fields_spec.rb
+++ b/spec/quantum_fields_spec.rb
@@ -14,17 +14,37 @@ ActiveRecord::Schema.define do
 end
 
 class MyModel < ActiveRecord::Base
+  no_sqlize fields_column: :my_json_field
 end
 
 RSpec.describe QuantumFields do
   describe ActiveRecord::Base do
     it { expect(described_class).to respond_to(:no_sqlize) }
 
-    describe "basic adapter json field capability" do
+    describe 'basic adapter json field capability' do
       let(:my_instance) { MyModel.create(my_json_field: { a_column_that_does_not_exists: 'I do exist'}) }
 
-      it "persist a property in a json field" do
-        expect(my_instance.my_json_field["a_column_that_does_not_exists"]).to eq "I do exist"
+      it 'persist a property in a json field' do
+        expect(my_instance.my_json_field['a_column_that_does_not_exists']).to eq 'I do exist'
+      end
+    end
+
+    describe 'virtualization of json keys and values as attributes on queries' do
+      let(:my_instance) { MyModel.create(god: 'Here I am') }
+      let(:third) { MyModel.create(lero: 3, orderable: 'true') }
+      let(:first) { MyModel.create(lero: 1, orderable: 'true') }
+      let(:second) { MyModel.create(lero: 2, orderable: 'true') }
+
+      it 'persist a property and it can be accessible as an attribute' do
+        expect(my_instance.god).to eq 'Here I am'
+      end
+
+      it 'is queryable as a common attribute' do
+        expect(MyModel.where(god: 'Here I am')).to include my_instance
+      end
+
+      it 'is orderable as a common attribute' do
+        expect(MyModel.order(:lero).where(orderable: 'true')).to eq [first, second, third]
       end
     end
   end


### PR DESCRIPTION
This abstracts database support into separated modules and injects field parsing based on current database connections. This pull request also adds tests for core functionalities.